### PR TITLE
Changed ERC20 .sol files' syntax and formatting

### DIFF
--- a/erc20faucet/contracts/ERC20/ERC20.sol
+++ b/erc20faucet/contracts/ERC20/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.25;
 
 import "./IERC20.sol";
 import "../math/SafeMath.sol";
@@ -11,118 +11,107 @@ import "../math/SafeMath.sol";
  * Originally based on code by FirstBlood: https://github.com/Firstbloodio/token/blob/master/smart_contract/FirstBloodToken.sol
  */
 contract ERC20 is IERC20 {
-  using SafeMath for uint256;
 
-  mapping (address => uint256) private _balances;
+   using SafeMath for uint256;
 
-  mapping (address => mapping (address => uint256)) private _allowed;
+   uint256 private _totalSupply;
 
-  uint256 private _totalSupply;
+   mapping (address => uint256) private balances;
+   mapping (address => mapping (address => uint256)) private allowed;
 
-  /**
-  * @dev Total number of tokens in existence
-  */
-  function totalSupply() public view returns (uint256) {
-    return _totalSupply;
-  }
-
-  /**
-  * @dev Gets the balance of the specified address.
-  * @param owner The address to query the balance of.
-  * @return An uint256 representing the amount owned by the passed address.
-  */
-  function balanceOf(address owner) public view returns (uint256) {
-    return _balances[owner];
-  }
-
-  /**
-   * @dev Function to check the amount of tokens that an owner allowed to a spender.
-   * @param owner address The address which owns the funds.
-   * @param spender address The address which will spend the funds.
-   * @return A uint256 specifying the amount of tokens still available for the spender.
+   /**
+    * @dev Total number of tokens in existence
    */
-  function allowance(
-    address owner,
-    address spender
-   )
-    public
-    view
-    returns (uint256)
-  {
-    return _allowed[owner][spender];
-  }
+   function totalSupply() public view returns (uint256) {
+      return _totalSupply;
+   }
 
-  /**
-  * @dev Transfer token for a specified address
-  * @param to The address to transfer to.
-  * @param value The amount to be transferred.
-  */
-  function transfer(address to, uint256 value) public returns (bool) {
-    _transfer(msg.sender, to, value);
-    return true;
-  }
-
-  /**
-   * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
-   * Beware that changing an allowance with this method brings the risk that someone may use both the old
-   * and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this
-   * race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards:
-   * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-   * @param spender The address which will spend the funds.
-   * @param value The amount of tokens to be spent.
+   /**
+    * @dev Gets the balance of the specified address.
+    * @param _owner The address to query the balance of.
+    * @return An uint256 representing the amount owned by the passed address.
    */
-  function approve(address spender, uint256 value) public returns (bool) {
-    require(spender != address(0));
+   function balanceOf(address _owner) public view returns (uint256) {
+      return balances[_owner];
+   }
 
-    _allowed[msg.sender][spender] = value;
-    emit Approval(msg.sender, spender, value);
-    return true;
-  }
+   /**
+    * @dev Function to check the amount of tokens that an owner allowed to a spender.
+    * @param _owner address The address which owns the funds.
+    * @param _spender address The address which will spend the funds.
+    * @return A uint256 specifying the amount of tokens still available for the spender.
+    */
+   function allowance(address _owner, address _spender) public view returns (uint256) {
+      return allowed[_owner][_spender];
+   }
 
-  /**
-   * @dev Transfer tokens from one address to another
-   * @param from address The address which you want to send tokens from
-   * @param to address The address which you want to transfer to
-   * @param value uint256 the amount of tokens to be transferred
-   */
-  function transferFrom(
-    address from,
-    address to,
-    uint256 value
-  )
-    public
-    returns (bool)
-  {
-    require(value <= _allowed[from][msg.sender]);
+   /**
+    * @dev Transfer token for a specified address
+    * @param _to The address to transfer to.
+    * @param _value The amount to be transferred.
+    */
+   function transfer(address _to, uint256 _value) public returns (bool) {
+      require(_value <= balances[msg.sender]);
+      require(_to != address(0));
 
-    _allowed[from][msg.sender] = _allowed[from][msg.sender].sub(value);
-    _transfer(from, to, value);
-    return true;
-  }
+      balances[msg.sender] = balances[msg.sender].sub(_value);
+      balances[_to] = balances[_to].add(_value);
+      emit Transfer(msg.sender, _to, _value);
+      return true;
+   }
 
-  /**
-   * @dev Increase the amount of tokens that an owner allowed to a spender.
-   * approve should be called when allowed_[_spender] == 0. To increment
-   * allowed value is better to use this function to avoid 2 calls (and wait until
-   * the first transaction is mined)
-   * From MonolithDAO Token.sol
-   * @param spender The address which will spend the funds.
-   * @param addedValue The amount of tokens to increase the allowance by.
-   */
-  function increaseAllowance(
-    address spender,
-    uint256 addedValue
-  )
-    public
-    returns (bool)
-  {
-    require(spender != address(0));
+   /**
+    * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+    * Beware that changing an allowance with this method brings the risk that someone may use both the old
+    * and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this
+    * race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards:
+    * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    * @param _spender The address which will spend the funds.
+    * @param _value The amount of tokens to be spent.
+    */
+   function approve(address _spender, uint256 _value) public returns (bool) {
+      require(_spender != address(0));
 
-    _allowed[msg.sender][spender] = (
-      _allowed[msg.sender][spender].add(addedValue));
-    emit Approval(msg.sender, spender, _allowed[msg.sender][spender]);
-    return true;
-  }
+      allowed[msg.sender][_spender] = _value;
+      emit Approval(msg.sender, _spender, _value);
+      return true;
+   }
+
+   /**
+    * @dev Transfer tokens from one address to another
+    * @param _from address The address which you want to send tokens from
+    * @param _to address The address which you want to transfer to
+    * @param _value uint256 the amount of tokens to be transferred
+    */
+   function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
+      require(_value <= balances[_from]);
+      require(_value <= allowed[_from][msg.sender]);
+      require(_to != address(0));
+
+      balances[_from] = balances[_from].sub(_value);
+      balances[_to] = balances[_to].add(_value);
+      allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
+      emit Transfer(_from, _to, _value);
+      return true;
+   }
+
+   /**
+    * @dev Increase the amount of tokens that an owner allowed to a spender.
+    * approve should be called when allowed_[_spender] == 0. To increment
+    * allowed value is better to use this function to avoid 2 calls (and wait until
+    * the first transaction is mined)
+    * From MonolithDAO Token.sol
+    * @param _spender The address which will spend the funds.
+    * @param _addedValue The amount of tokens to increase the allowance by.
+    */
+   function increaseAllowance(address _spender, uint256 _addedValue) public returns (bool) {
+      require(_spender != address(0));
+
+      allowed[msg.sender][_spender] = (
+      allowed[msg.sender][_spender].add(_addedValue));
+      emit Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+      return true;
+   }
 
   /**
    * @dev Decrease the amount of tokens that an owner allowed to a spender.
@@ -130,82 +119,64 @@ contract ERC20 is IERC20 {
    * allowed value is better to use this function to avoid 2 calls (and wait until
    * the first transaction is mined)
    * From MonolithDAO Token.sol
-   * @param spender The address which will spend the funds.
-   * @param subtractedValue The amount of tokens to decrease the allowance by.
+   * @param _spender The address which will spend the funds.
+   * @param _subtractedValue The amount of tokens to decrease the allowance by.
    */
-  function decreaseAllowance(
-    address spender,
-    uint256 subtractedValue
-  )
-    public
-    returns (bool)
-  {
-    require(spender != address(0));
+   function decreaseAllowance(address _spender, uint256 _subtractedValue) public returns (bool) {
+      require(_spender != address(0));
 
-    _allowed[msg.sender][spender] = (
-      _allowed[msg.sender][spender].sub(subtractedValue));
-    emit Approval(msg.sender, spender, _allowed[msg.sender][spender]);
-    return true;
-  }
+      allowed[msg.sender][_spender] = (allowed[msg.sender][_spender].sub(_subtractedValue));
+      emit Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+      return true;
+   }
 
-  /**
-  * @dev Transfer token for a specified addresses
-  * @param from The address to transfer from.
-  * @param to The address to transfer to.
-  * @param value The amount to be transferred.
-  */
-  function _transfer(address from, address to, uint256 value) internal {
-    require(value <= _balances[from]);
-    require(to != address(0));
+   /**
+    * @dev Internal function that mints an amount of the token and assigns it to
+    * an account. This encapsulates the modification of balances such that the
+    * proper events are emitted.
+    * @param _account The account that will receive the created tokens.
+    * @param _amount The amount that will be created.
+    */
+   function _mint(address _account, uint256 _amount) internal {
+      require(_account != 0);
+      require(_totalSupply.add(_amount) <= maxSupply);
+      _totalSupply = _totalSupply.add(_amount);
+      balances[_account] = balances[_account].add(_amount);
+      emit Transfer(address(0), _account, _amount);
+   }
 
-    _balances[from] = _balances[from].sub(value);
-    _balances[to] = _balances[to].add(value);
-    emit Transfer(from, to, value);
-  }
+   /**
+    * @dev Internal function that burns an amount of the token of a given
+    * account.
+    * @param _account The account whose tokens will be burnt.
+    * @param _amount The amount that will be burnt.
+    */
+   function _burn(address _account, uint256 _amount) internal {
+      require(_account != 0);
+      require(_amount <= balances[_account]);
 
-  /**
-   * @dev Internal function that mints an amount of the token and assigns it to
-   * an account. This encapsulates the modification of balances such that the
-   * proper events are emitted.
-   * @param account The account that will receive the created tokens.
-   * @param value The amount that will be created.
-   */
-  function _mint(address account, uint256 value) internal {
-    require(account != 0);
-    _totalSupply = _totalSupply.add(value);
-    _balances[account] = _balances[account].add(value);
-    emit Transfer(address(0), account, value);
-  }
+      _totalSupply = _totalSupply.sub(_amount);
+      balances[_account] = balances[_account].sub(_amount);
+      emit Transfer(_account, address(0), _amount);
+   }
 
-  /**
-   * @dev Internal function that burns an amount of the token of a given
-   * account.
-   * @param account The account whose tokens will be burnt.
-   * @param value The amount that will be burnt.
-   */
-  function _burn(address account, uint256 value) internal {
-    require(account != 0);
-    require(value <= _balances[account]);
+   /**
+    * @dev Internal function that burns an amount of the token of a given
+    * account, deducting from the sender's allowance for said account. Uses the
+    * internal burn function.
+    * @param _account The account whose tokens will be burnt.
+    * @param _amount The amount that will be burnt.
+    */
+   function _burnFrom(address _account, uint256 _amount) internal {
+      require(_amount <= allowed[_account][msg.sender]);
 
-    _totalSupply = _totalSupply.sub(value);
-    _balances[account] = _balances[account].sub(value);
-    emit Transfer(account, address(0), value);
-  }
+      // Should https://github.com/OpenZeppelin/zeppelin-solidity/issues/707 be accepted,
+      // this function needs to emit an event with the updated approval.
+      allowed[_account][msg.sender] = allowed[_account][msg.sender].sub(_amount);
+      _burn(_account, _amount);
+   }
 
-  /**
-   * @dev Internal function that burns an amount of the token of a given
-   * account, deducting from the sender's allowance for said account. Uses the
-   * internal burn function.
-   * @param account The account whose tokens will be burnt.
-   * @param value The amount that will be burnt.
-   */
-  function _burnFrom(address account, uint256 value) internal {
-    require(value <= _allowed[account][msg.sender]);
-
-    // Should https://github.com/OpenZeppelin/zeppelin-solidity/issues/707 be accepted,
-    // this function needs to emit an event with the updated approval.
-    _allowed[account][msg.sender] = _allowed[account][msg.sender].sub(
-      value);
-    _burn(account, value);
-  }
+    event Transfer(address indexed _from, address indexed _to, uint256 _value);
+    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
 }
+

--- a/erc20faucet/contracts/ERC20/ERC20Burnable.sol
+++ b/erc20faucet/contracts/ERC20/ERC20Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.25;
 
 import "./ERC20.sol";
 

--- a/erc20faucet/contracts/ERC20/ERC20Capped.sol
+++ b/erc20faucet/contracts/ERC20/ERC20Capped.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.25;
 
 import "./ERC20Mintable.sol";
 

--- a/erc20faucet/contracts/ERC20/ERC20Detailed.sol
+++ b/erc20faucet/contracts/ERC20/ERC20Detailed.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.25;
 
 import "./IERC20.sol";
 

--- a/erc20faucet/contracts/ERC20/IERC20.sol
+++ b/erc20faucet/contracts/ERC20/IERC20.sol
@@ -5,30 +5,15 @@ pragma solidity ^0.4.24;
  * @dev see https://github.com/ethereum/EIPs/issues/20
  */
 interface IERC20 {
-  function totalSupply() external view returns (uint256);
 
-  function balanceOf(address who) external view returns (uint256);
+   function totalSupply() external view returns (uint256);
+   function balanceOf(address _owner) external view returns (uint256 balance);
+   function transfer(address _to, uint256 _value) external returns (bool success);
+   function transferFrom(address _from, address _to, uint256 _value) external returns (bool success);
+   function approve(address _spender, uint256 _value) external returns (bool success);
+   function allowance(address _owner, address _spender) external view returns (uint256 remaining);
 
-  function allowance(address owner, address spender)
-    external view returns (uint256);
+   event Transfer(address indexed _from, address indexed _to, uint256 _value);
+   event Approval(address indexed _owner, address indexed _spender, uint256 _value);
 
-  function transfer(address to, uint256 value) external returns (bool);
-
-  function approve(address spender, uint256 value)
-    external returns (bool);
-
-  function transferFrom(address from, address to, uint256 value)
-    external returns (bool);
-
-  event Transfer(
-    address indexed from,
-    address indexed to,
-    uint256 value
-  );
-
-  event Approval(
-    address indexed owner,
-    address indexed spender,
-    uint256 value
-  );
 }

--- a/erc20faucet/contracts/ERC20/TNetToken.sol
+++ b/erc20faucet/contracts/ERC20/TNetToken.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.25;
+
+import "./ERC20.sol";
+import "./ERC20Detailed.sol";
+import "./ERC20Mintable.sol";
+import "./ERC20Burnable.sol";
+
+contract TNetToken is ERC20, ERC20Detailed, ERC20Mintable, ERC20Burnable {
+
+   //Hardcoding here by overriding constructor. This should be valid, I think...?
+   constructor() public {
+      _name = "TNetToken";
+      _symbol = "TNT";
+      _decimals = "18";
+   }
+
+
+}
+


### PR DESCRIPTION
Hello,

I felt that the expanded version that OpenZeppelin uses is difficult to read, so I changed it to a more legible version that is more "compact" and easier to trace from left-to-right. This has been done for ERC20.sol and IERC20.sol. 

Aside from formatting, some variable name syntax has been changed; I personally feel that prefixing local/internal vars with underscores ("\_") helps greatly with readability, since it becomes very clear which variable the permanent ones are. Perhaps the only inconsistency is with persistent private variables being denoted by "\_", which now no longer have it, which could imply public variable depending on the way you see it. Perhaps adding a \_ as a suffix for the parameters where they conflict with internal names...? (the doc "Style Guide" suggests the "\_" suffix as a valid idea, see https://solidity.readthedocs.io/en/v0.4.25/style-guide.html under "Avoiding Naming Collisions").

```
Avoiding Naming Collisions

- single_trailing_underscore_

This convention is suggested when the desired name collides with that of a built-in or otherwise reserved name.
```

Finally, TNetToken.sol has been created, extending from many of the ERC20 OpenZeppelin contracts such as ERC20, ERC20Detailed, ERC20Mintable, and ERC20Burnable. I realized that a neat solution to keep a pre-defined "constant" name, symbol, and decimal would be to override the constructor and just define it there. I think it fits in with multiple inheritance in Solidity...?

Please let me know what you guys think about this. Thanks!